### PR TITLE
Update ExpTracker to works in all language

### DIFF
--- a/OccultCrescentHelper/Modules/Exp/ExpTracker.cs
+++ b/OccultCrescentHelper/Modules/Exp/ExpTracker.cs
@@ -2,25 +2,28 @@ using System;
 using System.Text.RegularExpressions;
 using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling;
+using ECommons.DalamudServices;
+using ClientLanguage = Dalamud.Game.ClientLanguage;
 
 namespace OccultCrescentHelper.Modules.Exp;
 
 public class ExpTracker
 {
     private float exp = 0f;
+    private readonly string pattern;
 
     private DateTime startTime = DateTime.UtcNow;
 
     public ExpTracker()
     {
         Reset();
+        pattern = getExpMessagePattern(Svc.ClientState.ClientLanguage);
     }
 
     public void OnTerritoryChange(ushort _) => Reset();
 
     public void OnChatMessage(XivChatType type, int timestamp, SeString sender, SeString message, bool isHandled)
     {
-        var pattern = @"You gain (\d+) Phantom .+? experience points\.";
         var match = Regex.Match(message.ToString(), pattern);
         if (match.Success)
         {
@@ -41,5 +44,15 @@ public class ExpTracker
             return 0;
 
         return (exp) / elapsed;
+    }
+
+    private string getExpMessagePattern(ClientLanguage clientLanguage)
+    {
+        return clientLanguage switch {
+            ClientLanguage.English => @"You gain (\d+) Phantom .+? experience points\.",
+            ClientLanguage.French =>  @"Vous gagnez (\d+) points d'expérience de soutien en .+? fantôme",
+            ClientLanguage.German =>  @"Du erhältst (\d+) Phantomroutine als Phantom",
+            ClientLanguage.Japanese =>  @".+?」に(\d+)ポイントのサポート経験値を得た。",
+        };
     }
 }


### PR DESCRIPTION
Tried a bit to farm gold, saw it wasn't working in my language.

Updated a bit how the pattern works, when we initialize the ExpTracker, we get the GameClientLanguage that then resolve to a different pattern 