### PR TITLE
Fix ArgumentOutOfRangeException at end of Hunter run

### DIFF
--- a/BOCCHI/Pathfinding/Hunter.cs
+++ b/BOCCHI/Pathfinding/Hunter.cs
@@ -148,6 +148,12 @@ public abstract class Hunter
             return;
         }
 
+        if (stepIndex >= Steps.Count)
+        {
+            Teardown();
+            return;
+        }
+
         StepProcessor.Submit(() =>
             Chain.Create("Hunter.Run")
                 .Then(_ =>
@@ -161,19 +167,11 @@ public abstract class Hunter
                 .Wait(1000 / 60)
         );
 
-
-        if (stepIndex < Steps.Count)
+        var obj = GetValidObjects().FirstOrDefault(o => Vector3.Distance(Player.Position, o.Position) <= 5f);
+        if (obj != null)
         {
-            var obj = GetValidObjects().FirstOrDefault(o => Vector3.Distance(Player.Position, o.Position) <= 5f);
-            if (obj != null)
-            {
-                StepProcessor.Submit(GetInteractionChain(obj));
-            }
-
-            return;
+            StepProcessor.Submit(GetInteractionChain(obj));
         }
-
-        Teardown();
     }
 
     public void Draw(Module<Plugin, Config> module)
@@ -218,7 +216,7 @@ public abstract class Hunter
             }
 
 
-            if (running && Steps.Count > 0)
+            if (running && stepIndex < Steps.Count)
             {
                 OcelotUi.LabelledValue(I18N.T("hunter.progress"), $"{stepIndex}/{Steps.Count}");
 


### PR DESCRIPTION
Treasure Hunt and Carrot Hunt reliably threw `System.ArgumentOutOfRangeException` when the final pathfinder step completed. `Hunter.Draw` accessed `CurrentStep` (= `Steps[stepIndex]`) under a guard that only checked `Steps.Count > 0`, but `stepIndex` was already equal to `Steps.Count` after the last step's handler returned `true`. `MaintainWatcherChain` also queued one more handler chain past the end of `Steps` before reaching `Teardown()`.

- `Hunter.MaintainWatcherChain`: check `stepIndex >= Steps.Count` and `Teardown()` before submitting any new handler chain.
- `Hunter.Draw`: bound-check `stepIndex < Steps.Count` in the UI guard so render order vs. update order can't cause the throw.

Single file changed: `BOCCHI/Pathfinding/Hunter.cs`. The fix lives in the shared base class, so both `TreasureModule` and `CarrotsModule` benefit.

Stack trace this fixes:

```
System.ArgumentOutOfRangeException: Index was out of range. ... (Parameter 'index')
   at BOCCHI.Pathfinding.Hunter.<>c__DisplayClass25_0.<Draw>b__0() in BOCCHI/Pathfinding/Hunter.cs:line 230
   at BOCCHI.Pathfinding.Hunter.Draw(Module`2 module)            in BOCCHI/Pathfinding/Hunter.cs:line 182
   at BOCCHI.Modules.Treasure.TreasureModule.RenderMainUi(...)   in BOCCHI/Modules/Treasure/TreasureModule.cs:line 67
```