### PR TITLE
fix: only approach FATE and CE targets once

### DIFF
--- a/BOCCHI.Automator/StateMachine/Handlers/CombatActivityHandler.cs
+++ b/BOCCHI.Automator/StateMachine/Handlers/CombatActivityHandler.cs
@@ -16,7 +16,11 @@ internal static class CombatActivityHandler
     /// <summary>Standard max-melee distance past the target hitbox.</summary>
     private const float MaxMeleeRange = 3f;
 
-    public static void HandleTargets(
+    /// <returns>
+    ///     <see langword="true"/> once the activity's initial approach was issued,
+    ///     was already unnecessary, or was superseded by entering combat.
+    /// </returns>
+    public static bool HandleTargets(
         IGameObject player,
         IEnumerable<IBattleNpc> targets,
         CombatConfig combat,
@@ -24,6 +28,7 @@ internal static class CombatActivityHandler
         ICondition conditions,
         IPathfinder pathfinder,
         string throttlePrefix,
+        bool shouldApproachTarget,
         bool stopPathfinderInCombat = false
     )
     {
@@ -31,7 +36,7 @@ internal static class CombatActivityHandler
         IBattleNpc? target = TargetHelper.Select(list, combat.ForceTargetCentralEnemy);
         if (target == null)
         {
-            return;
+            return false;
         }
 
         if (combat.ShouldHandleTargeting
@@ -51,27 +56,36 @@ internal static class CombatActivityHandler
             }
         }
 
-        // Walk into max melee of the boss/pack — don't sit at the FATE circle edge (~20y).
-        if (distance > MaxMeleeRange)
-        {
-            if (EzThrottler.Throttle($"{throttlePrefix}::Approach", 500) && pathfinder.IsIdle())
-            {
-                float arrival = Math.Max(0.5f, target.HitboxRadius + MaxMeleeRange);
-                pathfinder.PathfindAndMoveTo(new PathfinderConfig(target.Position)
-                {
-                    DistanceThreshold = arrival,
-                    ShouldSnapToFloor = true,
-                });
-            }
-
-            return;
-        }
-
-        pathfinder.Stop();
-
+        // Once combat has started, FATE movement is deliberately handed back to the player.
+        // This must precede the out-of-range branch so that branch cannot re-start navigation.
         if (stopPathfinderInCombat && conditions[ConditionFlag.InCombat])
         {
             pathfinder.Stop();
+            return true;
         }
+
+        if (distance <= MaxMeleeRange)
+        {
+            pathfinder.Stop();
+            return true;
+        }
+
+        // Only issue the max-melee movement once for this FATE/CE. The caller keeps
+        // this completed across handler re-entry and re-arms it for a different event.
+        if (!shouldApproachTarget
+            || !EzThrottler.Throttle($"{throttlePrefix}::Approach", 500)
+            || !pathfinder.IsIdle())
+        {
+            return false;
+        }
+
+        float arrival = Math.Max(0.5f, target.HitboxRadius + MaxMeleeRange);
+        pathfinder.PathfindAndMoveTo(new PathfinderConfig(target.Position)
+        {
+            DistanceThreshold = arrival,
+            ShouldSnapToFloor = true,
+        });
+
+        return true;
     }
 }

--- a/BOCCHI.Automator/StateMachine/Handlers/InCriticalEncounterHandler.cs
+++ b/BOCCHI.Automator/StateMachine/Handlers/InCriticalEncounterHandler.cs
@@ -1,5 +1,6 @@
 ﻿using BOCCHI.Automator.Data;
 using BOCCHI.Common.Config;
+using BOCCHI.Common.Data.CriticalEncounters;
 using BOCCHI.Common.Data.StateMemory;
 using BOCCHI.Common.Services;
 using Dalamud.Game.ClientState.Conditions;
@@ -22,7 +23,13 @@ public class InCriticalEncounterHandler
     ITargetManager targetManager
 ) : ScoreStateHandler<AutomatorState, StatePriority>(AutomatorState.InCriticalEncounter)
 {
-    public override StatePriority GetScore() => context.IsInCriticalEncounter() ? StatePriority.VeryHigh : StatePriority.Never;
+    public override StatePriority GetScore()
+    {
+        CriticalEncounterId? currentEncounterId = context.GetCriticalEncounterId();
+        GetApproachMemory(currentEncounterId);
+
+        return currentEncounterId != null ? StatePriority.VeryHigh : StatePriority.Never;
+    }
 
     public override void Enter()
     {
@@ -45,14 +52,32 @@ public class InCriticalEncounterHandler
             pathfinder.Stop();
         }
 
-        CombatActivityHandler.HandleTargets(
+        InitialCombatApproachMemory<CriticalEncounterId> approach = GetApproachMemory(context.GetCriticalEncounterId());
+
+        if (CombatActivityHandler.HandleTargets(
             player,
             context.GetTargets(),
             combat,
             targetManager,
             conditions,
             pathfinder,
-            "InCriticalEncounter"
-        );
+            "InCriticalEncounter",
+            approach.IsPending
+        ))
+        {
+            approach.Complete();
+        }
+    }
+
+    private InitialCombatApproachMemory<CriticalEncounterId> GetApproachMemory(CriticalEncounterId? encounterId)
+    {
+        if (!memory.TryRemember(out InitialCombatApproachMemory<CriticalEncounterId> approach))
+        {
+            approach = new();
+            memory.TryAdd(approach);
+        }
+
+        approach.Track(encounterId);
+        return approach;
     }
 }

--- a/BOCCHI.Automator/StateMachine/Handlers/InFateHandler.cs
+++ b/BOCCHI.Automator/StateMachine/Handlers/InFateHandler.cs
@@ -1,5 +1,6 @@
 using BOCCHI.Automator.Data;
 using BOCCHI.Common.Config;
+using BOCCHI.Common.Data.Fates;
 using BOCCHI.Common.Data.Goals;
 using BOCCHI.Common.Data.StateMemory;
 using BOCCHI.Common.Services;
@@ -29,12 +30,15 @@ public class InFateHandler
 
     public override StatePriority GetScore()
     {
+        FateId? currentFateId = context.GetFateId();
+        GetApproachMemory(currentFateId);
+
         if (!memory.TryRemember<GoalMemory>(out GoalMemory goal) || goal.Goal.GoalType is not FateGoal fateGoal)
         {
             return StatePriority.Never;
         }
 
-        return context.GetFateId() == fateGoal.id ? StatePriority.VeryHigh : StatePriority.Never;
+        return currentFateId == fateGoal.id ? StatePriority.VeryHigh : StatePriority.Never;
     }
 
     public override void Handle()
@@ -45,6 +49,7 @@ public class InFateHandler
         }
 
         List<IBattleNpc> targets = context.GetTargets().ToList();
+        InitialCombatApproachMemory<FateId> approach = GetApproachMemory(context.GetFateId());
 
         // Stay mounted until within range of a FATE target.
         if (conditions[ConditionFlag.Mounted]
@@ -57,7 +62,7 @@ public class InFateHandler
             pathfinder.Stop();
         }
 
-        CombatActivityHandler.HandleTargets(
+        if (CombatActivityHandler.HandleTargets(
             player,
             targets,
             combat,
@@ -65,7 +70,23 @@ public class InFateHandler
             conditions,
             pathfinder,
             "InFate",
+            approach.IsPending,
             true
-        );
+        ))
+        {
+            approach.Complete();
+        }
+    }
+
+    private InitialCombatApproachMemory<FateId> GetApproachMemory(FateId? fateId)
+    {
+        if (!memory.TryRemember(out InitialCombatApproachMemory<FateId> approach))
+        {
+            approach = new();
+            memory.TryAdd(approach);
+        }
+
+        approach.Track(fateId);
+        return approach;
     }
 }

--- a/BOCCHI.Common/Data/StateMemory/StateMemories.cs
+++ b/BOCCHI.Common/Data/StateMemory/StateMemories.cs
@@ -19,6 +19,31 @@ public class WaitingForCriticalEncounterMemory;
 /// </summary>
 public sealed class NavigationInterruptedMemory;
 
+/// <summary>
+///     Tracks the one initial combat approach for the lifetime of an activity.
+///     A different activity ID re-arms it; temporary Automator state changes do not.
+/// </summary>
+public sealed class InitialCombatApproachMemory<TActivityId>
+    where TActivityId : struct
+{
+    private TActivityId? activityId;
+
+    public bool IsPending { get; private set; }
+
+    public void Track(TActivityId? currentActivityId)
+    {
+        if (EqualityComparer<TActivityId?>.Default.Equals(activityId, currentActivityId))
+        {
+            return;
+        }
+
+        activityId = currentActivityId;
+        IsPending = currentActivityId.HasValue;
+    }
+
+    public void Complete() => IsPending = false;
+}
+
 public sealed class GoalMemory(IGoal goal)
 {
     public IGoal Goal


### PR DESCRIPTION
Fixes FATE/CE automation repeatedly pulling the player back into melee range after they manually move away.

The initial melee approach now runs once per encounter and resets when the active FATE/CE changes.