### PR TITLE
fix: abandon CEs that start before arrival

### DIFF
--- a/BOCCHI.Automator/Services/Goals/GoalValidator.cs
+++ b/BOCCHI.Automator/Services/Goals/GoalValidator.cs
@@ -10,6 +10,7 @@ namespace BOCCHI.Automator.Services.Goals;
 public class GoalValidator
 (
     ICriticalEncounterRepository criticalEncounterRepository,
+    ICriticalEncounterContext criticalEncounterContext,
     IFateRepository fateRepository,
     IZoneProvider zones,
     FatesConfig fatesConfig,
@@ -41,9 +42,10 @@ public class GoalValidator
             return false;
         }
 
-        // Keep while Register/Warmup/Battle. Drop as soon as the CE ends so we can Return/rechoose
-        // instead of sitting on an empty path until the event goes Inactive.
-        return ce.IsPreparing() || ce.IsActive();
+        // Once Battle starts, keep the goal only if we actually made it into this CE. An active CE
+        // cannot be entered from outside, so abort its path and choose another activity immediately.
+        return ce.IsPreparing()
+               || (ce.IsActive() && criticalEncounterContext.GetCriticalEncounterId() == id);
     }
 
     private bool ValidateFate(FateId id)


### PR DESCRIPTION
Stops Illegal Mode from continuing toward a CE once it has commenced unless the player is already inside the CE. Stale CE navigation is cancelled and task selection resumes, covering both en-route and queued-after-FATE cases.