### PR TITLE
Respect Treasure Hunt max level in Pots & Treasure

### DIFF
--- a/BOCCHI.Automator/Services/PotsTreasureService.cs
+++ b/BOCCHI.Automator/Services/PotsTreasureService.cs
@@ -39,8 +39,6 @@ public class PotsTreasureService
 
     private static readonly TimeSpan ManualTreasureOverride = TimeSpan.FromMinutes(5);
 
-    private const int PotsTreasureHuntMaxLevel = 50;
-
     private readonly HashSet<uint> visitedTreasureNodes = [];
 
     private DateTimeOffset nextTreasureHuntAt = DateTimeOffset.MinValue;
@@ -172,7 +170,7 @@ public class PotsTreasureService
                 return;
             }
 
-            hunter.ConfigureManagedRun(visitedTreasureNodes, PotsTreasureHuntMaxLevel);
+            hunter.ConfigureManagedRun(visitedTreasureNodes);
             hunter.StartManaged();
             huntWasRunning = hunter.Running;
             logger.Info("Pots & Treasure: started treasure hunt filler");


### PR DESCRIPTION
## Summary
- Make Pots & Treasure treasure-hunt filler respect the normal Treasure Hunt max-level setting.
- Remove the hardcoded P&T-only max level of 50.

## Why
Pots & Treasure previously passed a fixed max level of 50 into the managed treasure hunt run. This could route players into higher-level/dangerous coffer areas even when their regular Treasure Hunt configuration was set lower for safer routing.

With this change, P&T no longer supplies a max-level override, so TreasureHunterService falls back to `TreasureConfig.HuntMaxLevel` just like a normal treasure hunt.

## Testing
- Not built locally: upstream currently references Ocelot submodule commit `9d337e9f9c5836ea9069091f9612b1ecb5bfa1af`, which is not available from `OhKannaDuh/Ocelot`, so the submodule cannot be checked out and the build fails before this change can be validated.