### PR TITLE
Fix CE wait registration handoff

### DIFF
--- a/BOCCHI.Automator/Services/Goals/GoalValidator.cs
+++ b/BOCCHI.Automator/Services/Goals/GoalValidator.cs
@@ -4,6 +4,7 @@ using BOCCHI.Common.Config;
 using BOCCHI.Common.Data.CriticalEncounters;
 using BOCCHI.Common.Data.Fates;
 using BOCCHI.Common.Data.Goals;
+using BOCCHI.Common.Data.StateMemory;
 using BOCCHI.Common.Data.Zones;
 using BOCCHI.Common.Services;
 
@@ -20,7 +21,8 @@ public class GoalValidator
     PotsConfig potsConfig,
     CriticalEncountersConfig criticalEncountersConfig,
     IPotCycleTracker potCycle,
-    IAutomatorContext automatorContext
+    IAutomatorContext automatorContext,
+    IAutomatorMemory memory
 ) : IGoalValidator
 {
     public bool Validate(IGoal goal)
@@ -53,10 +55,31 @@ public class GoalValidator
             return false;
         }
 
-        // Keep while Register/Warmup. During Battle only if this character is participating
-        // (player EventId) — zone CurrentEventId alone is not enough; outside players cannot join.
-        return ce.IsPreparing()
-               || (ce.IsActive() && criticalEncounterContext.GetCriticalEncounterId() == id);
+        if (ce.IsPreparing())
+        {
+            return true;
+        }
+
+        if (!ce.IsActive())
+        {
+            return false;
+        }
+
+        // During Battle, prefer the player's CE event id. If we had already reached the CE wait
+        // area before it started, keep the goal so we do not path out to another activity.
+        if (criticalEncounterContext.GetCriticalEncounterId() == id)
+        {
+            return true;
+        }
+
+        if (!memory.TryRemember<WaitingForCriticalEncounterMemory>(out WaitingForCriticalEncounterMemory wait)
+            || !wait.IsFor(id))
+        {
+            return false;
+        }
+
+        wait.MarkBattleStarted();
+        return true;
     }
 
     private bool ValidateFate(FateId id)

--- a/BOCCHI.Automator/Services/Paths/PathCalculator.cs
+++ b/BOCCHI.Automator/Services/Paths/PathCalculator.cs
@@ -83,18 +83,21 @@ public class PathCalculator
         }
 
         float ceCombatRadius = 0f;
+        float ceWaitRadius = 0f;
         if (goal.GoalType is CriticalEncounterGoal ceGoalForRadius)
         {
             ceCombatRadius = zone.GetCriticalEncounterData()
                 .FirstOrDefault(a => a.Id == ceGoalForRadius.id.Value)?.CombatRadius ?? 0f;
+            ceWaitRadius = ceCombatRadius > 0f
+                ? NavigationConstants.CriticalEncounterWaitRadius(ceCombatRadius)
+                : 0f;
         }
 
         Vector3 arrivalCheck = potPrepositionStandOff ?? pathGoal.Position;
         float distanceToGoal = player.Position.Distance2D(arrivalCheck);
         if (ceCombatRadius > 0f)
         {
-            float waitRadius = NavigationConstants.CriticalEncounterWaitRadius(ceCombatRadius);
-            if (distanceToGoal <= waitRadius)
+            if (distanceToGoal <= ceWaitRadius)
             {
                 logger.Debug("Inside CE wait area.");
                 return [];
@@ -116,7 +119,7 @@ public class PathCalculator
             ? player.Position.Distance2D(camp.Position)
             : float.MaxValue;
         bool nearCriticalEncounter = ceCombatRadius > 0f
-                                     && distanceToGoal <= NavigationConstants.CriticalEncounterWaitRadius(ceCombatRadius);
+                                     && distanceToGoal <= ceWaitRadius;
         if (!nearCriticalEncounter
             && distanceToGoal > NavigationConstants.MaxDirectWalkDistance
             && distanceToGoal >= distToCamp * 0.5f)

--- a/BOCCHI.Automator/StateMachine/Handlers/WaitingForCriticalEncounterHandler.cs
+++ b/BOCCHI.Automator/StateMachine/Handlers/WaitingForCriticalEncounterHandler.cs
@@ -19,7 +19,8 @@ using Ocelot.States.Score;
 namespace BOCCHI.Automator.StateMachine.Handlers;
 
 /// <summary>
-///     Hold near a preparing CE until Battle. Travel delivers via PathCalculator; this state never vnavs.
+///     Hold near a CE after arrival. Travel delivers via PathCalculator; this state prevents leaving
+///     for another activity while the arrived CE moves from preparation into Battle.
 /// </summary>
 public class WaitingForCriticalEncounterHandler
 (
@@ -30,6 +31,7 @@ public class WaitingForCriticalEncounterHandler
     IVNavmeshIpc vnav,
     IChainManager manager,
     ICriticalEncounterRepository repo,
+    ICriticalEncounterContext context,
     AutomatorConfig config
 ) : ScoreStateHandler<AutomatorState, StatePriority>(AutomatorState.WaitingForCriticalEncounter)
 {
@@ -40,13 +42,32 @@ public class WaitingForCriticalEncounterHandler
             return StatePriority.Never;
         }
 
-        if (!TryGetPreparingGoal(out CriticalEncounter ce))
+        if (!TryGetGoalEncounter(out CriticalEncounter ce))
         {
             return StatePriority.Never;
         }
 
-        float waitRadius = MathF.Max(1f, ce.Radius);
+        float combatRadius = NavigationConstants.CriticalEncounterRedRadius(ce.Radius);
+        float waitRadius = NavigationConstants.CriticalEncounterWaitRadius(combatRadius);
         if (player.Position.Distance2D(ce.Position) >= waitRadius)
+        {
+            return StatePriority.Never;
+        }
+
+        if (ce.IsActive())
+        {
+            if (context.GetCriticalEncounterId() == ce.Id)
+            {
+                return StatePriority.Never;
+            }
+
+            return memory.TryRemember<WaitingForCriticalEncounterMemory>(out WaitingForCriticalEncounterMemory wait)
+                   && wait.IsFor(ce.Id)
+                ? StatePriority.VeryHigh
+                : StatePriority.Never;
+        }
+
+        if (!ce.IsPreparing())
         {
             return StatePriority.Never;
         }
@@ -60,17 +81,36 @@ public class WaitingForCriticalEncounterHandler
         base.Enter();
         StopNavigation();
         memory.Forget<GoalPathStepMemory>();
-        memory.TryAdd(new WaitingForCriticalEncounterMemory());
+
+        if (TryGetGoalEncounter(out CriticalEncounter ce))
+        {
+            memory.Forget<WaitingForCriticalEncounterMemory>();
+            memory.TryAdd(new WaitingForCriticalEncounterMemory(ce.Id));
+        }
     }
 
     public override void Handle()
     {
-        if (!memory.TryRemember<WaitingForCriticalEncounterMemory>(out _))
+        if (!memory.TryRemember<WaitingForCriticalEncounterMemory>(out WaitingForCriticalEncounterMemory wait))
         {
             return;
         }
 
-        if (!TryGetPreparingGoal(out _))
+        if (!TryGetGoalEncounter(out CriticalEncounter ce))
+        {
+            return;
+        }
+
+        if (!wait.IsFor(ce.Id))
+        {
+            return;
+        }
+
+        if (ce.IsActive())
+        {
+            wait.MarkBattleStarted();
+        }
+        else if (!ce.IsPreparing())
         {
             return;
         }
@@ -86,7 +126,7 @@ public class WaitingForCriticalEncounterHandler
         }
     }
 
-    private bool TryGetPreparingGoal(out CriticalEncounter ce)
+    private bool TryGetGoalEncounter(out CriticalEncounter ce)
     {
         ce = null!;
 
@@ -97,12 +137,12 @@ public class WaitingForCriticalEncounterHandler
         }
 
         CriticalEncounter? found = repo.SnapshotWithoutForkedTower().FirstOrDefault(c => c.Id == ceGoal.id);
-        if (found is not { } preparing || !preparing.IsPreparing())
+        if (found is not { } encounter)
         {
             return false;
         }
 
-        ce = preparing;
+        ce = encounter;
         return true;
     }
 

--- a/BOCCHI.Common/Data/StateMemory/StateMemories.cs
+++ b/BOCCHI.Common/Data/StateMemory/StateMemories.cs
@@ -35,7 +35,19 @@ public sealed class AutomaticTreasureSurveyMemory
     public DateTime SurveyWaitDeadlineUtc { get; set; }
 }
 
-public sealed class WaitingForCriticalEncounterMemory;
+public sealed class WaitingForCriticalEncounterMemory(CriticalEncounterId encounterId)
+{
+    public CriticalEncounterId EncounterId { get; } = encounterId;
+
+    public DateTimeOffset? BattleStartedAtUtc { get; private set; }
+
+    public bool IsFor(CriticalEncounterId id) => EncounterId == id;
+
+    public void MarkBattleStarted()
+    {
+        BattleStartedAtUtc ??= DateTimeOffset.UtcNow;
+    }
+}
 
 /// <summary>
 ///     In FATE/CE combat — block travel replan until the activity goal is dropped.

--- a/BOCCHI.Common/Data/Zones/NavigationApproach.cs
+++ b/BOCCHI.Common/Data/Zones/NavigationApproach.cs
@@ -49,9 +49,11 @@ public static class NavigationConstants
     public static float CriticalEncounterYellowRadius(float paddedRadius) =>
         MathF.Max(0f, paddedRadius - CriticalEncounterYellowInset);
 
-    /// <summary>Padded green radius used as CE wait / travel-arrival area (live blue proxy).</summary>
+    public const float CriticalEncounterWaitRadiusYalms = 22f;
+
+    /// <summary>CE wait / travel-arrival radius. Keep tighter than the padded debug ring so Battle starts inside the live join area.</summary>
     public static float CriticalEncounterWaitRadius(float combatRadius) =>
-        MathF.Max(1f, combatRadius + CriticalEncounterRadiusPadding);
+        CriticalEncounterWaitRadiusYalms;
 }
 
 public static class NavigationApproach


### PR DESCRIPTION
## Summary
- Use a consistent 22y wait/arrival radius for all Critical Encounters instead of only handling one CE case.
- Remember the CE id once the player reaches the CE waiting area.
- Keep the CE goal during the transition from Preparing to Battle if the player was already waiting there, even if the local CE participation event id has not appeared yet.

## Why
This addresses a case where BOCCHI reaches a CE, waits for it to start, then drops the CE goal when Battle begins before the local participation event id is available. After that it can choose a FATE outside the CE and path toward the edge/walls instead.

Closes/addresses: https://github.com/OhKannaDuh/BOCCHI/issues/142

## Testing
- `dotnet build BOCCHI.sln -c Release -p:Platform=x64`
- Runtime verification is still pending because the game is under maintenance.