### PR TITLE
Add option to open BOCCHI on Crescent Isle entry

### DIFF
--- a/BOCCHI.Common/Config/UIConfig.cs
+++ b/BOCCHI.Common/Config/UIConfig.cs
@@ -44,6 +44,8 @@ public class UIConfig : IAutoConfig
     [EnumSelectDisplay<UILanguage, UILanguageDisplay>]
     public UILanguage Language { get; set; } = UILanguage.English;
 
+    [Checkbox] public bool OpenOnOccultCrescentEntry { get; set; } = false;
+
     [Checkbox] public bool ShowExperienceTracker { get; set; } = true;
 
     [Checkbox] public bool ShowExperienceTrackerGraph { get; set; } = false;

--- a/BOCCHI/Plugin.cs
+++ b/BOCCHI/Plugin.cs
@@ -69,6 +69,7 @@ public sealed class Plugin(IDalamudPluginInterface plugin, IPluginLog logger) : 
         services.AddSingleton<IConfigRenderer, ConfigRenderer>();
         services.AddSingleton<IAutomationModeGuard, AutomationModeGuard>();
         services.AddSingleton<OperationalStatusBar>();
+        services.AddSingleton<OccultCrescentWindowAutoOpener>();
         services.AddSingleton<IMainWindowTitleBarContributor, IllegalModeTitleBarContributor>();
         services.AddSingleton<IMainWindowTitleBarContributor, KofiTitleBarContributor>();
         services.AddSingleton<IFieldRenderer<MobMultiSelectAttribute>, MobMultiSelectRenderer>();

--- a/BOCCHI/Services/OccultCrescentWindowAutoOpener.cs
+++ b/BOCCHI/Services/OccultCrescentWindowAutoOpener.cs
@@ -1,0 +1,41 @@
+using BOCCHI.Common.Config;
+using BOCCHI.Common.Data.Zones;
+using Ocelot.Lifecycle;
+using Ocelot.Windows;
+
+namespace BOCCHI.Services;
+
+public sealed class OccultCrescentWindowAutoOpener(
+    UIConfig config,
+    IZoneProvider zoneProvider,
+    IEnumerable<IZone> zones,
+    IMainWindow window
+) : IOnStart, IOnTerritoryChanged
+{
+    private readonly Dictionary<ushort, IZone> zonesByTerritory = zones.ToDictionary(z => z.TerritoryType);
+
+    public int Order => -100;
+
+    public void OnStart()
+    {
+        OpenIfConfigured(zoneProvider.GetZone().IsOccultCrescentZone());
+    }
+
+    public void OnTerritoryChanged(uint territory)
+    {
+        OpenIfConfigured(
+            territory <= ushort.MaxValue
+            && zonesByTerritory.TryGetValue((ushort)territory, out IZone? zone)
+            && zone.IsOccultCrescentZone());
+    }
+
+    private void OpenIfConfigured(bool isOccultCrescentZone)
+    {
+        if (!config.OpenOnOccultCrescentEntry || !isOccultCrescentZone || window.IsOpen)
+        {
+            return;
+        }
+
+        window.IsOpen = true;
+    }
+}

--- a/Translations/en/config.ui.json
+++ b/Translations/en/config.ui.json
@@ -6,6 +6,10 @@
       "label": "Language",
       "tooltip": "Language used for BOCCHI’s windows and messages."
     },
+    "open_on_occult_crescent_entry": {
+      "label": "Open BOCCHI on Occult Crescent entry",
+      "tooltip": "Automatically open the BOCCHI main window when entering South or North Horn."
+    },
     "show_experience_tracker": {
       "label": "Show experience tracker",
       "tooltip": "Show the experience panel in the main window."

--- a/Translations/jp/config.ui.json
+++ b/Translations/jp/config.ui.json
@@ -6,6 +6,10 @@
       "label": "言語",
       "tooltip": "BOCCHI のウィンドウとメッセージに使う言語です。"
     },
+    "open_on_occult_crescent_entry": {
+      "label": "クレセントアイル入場時に BOCCHI を開く",
+      "tooltip": "南征編または北征編に入ったとき、BOCCHI のメインウィンドウを自動で開きます。"
+    },
     "show_experience_tracker": {
       "label": "経験値トラッカーを表示",
       "tooltip": "メインウィンドウに経験値パネルを表示します。"

--- a/Translations/jp/windows/main.json
+++ b/Translations/jp/windows/main.json
@@ -1,6 +1,6 @@
 {
   "title": "BOCCHI",
-  "unsupported_zone": "BOCCHI を使うには、オカルド・クレセント（南征編または北征編）へ行ってください。",
+  "unsupported_zone": "BOCCHI を使うには、クレセントアイル（南征編または北征編）へ行ってください。",
   "support": {
     "kofi_tooltip": "♥ Ko-fi（外で芝生に触れ続けられるように）"
   },

--- a/Translations/ko/config.ui.json
+++ b/Translations/ko/config.ui.json
@@ -6,6 +6,10 @@
       "label": "언어",
       "tooltip": "BOCCHI 창과 메시지에 쓰는 언어입니다."
     },
+    "open_on_occult_crescent_entry": {
+      "label": "Occult Crescent 입장 시 BOCCHI 열기",
+      "tooltip": "남쪽 뿔 또는 북쪽 뿔에 입장하면 BOCCHI 메인 창을 자동으로 엽니다."
+    },
     "show_experience_tracker": {
       "label": "경험치 추적기 표시",
       "tooltip": "메인 창에 경험치 패널을 표시합니다."

--- a/Translations/zh/config.ui.json
+++ b/Translations/zh/config.ui.json
@@ -6,6 +6,10 @@
       "label": "语言",
       "tooltip": "BOCCHI 窗口与消息使用的语言。"
     },
+    "open_on_occult_crescent_entry": {
+      "label": "进入 Occult Crescent 时打开 BOCCHI",
+      "tooltip": "进入 South Horn 或 North Horn 时自动打开 BOCCHI 主窗口。"
+    },
     "show_experience_tracker": {
       "label": "显示经验值统计",
       "tooltip": "在主窗口中显示经验值面板。"


### PR DESCRIPTION
## Summary
- Add a UI setting to automatically open the BOCCHI main window when entering an Occult Crescent zone.
- Register a small territory-change listener that opens the window on South Horn / North Horn entry when the setting is enabled.
- Update the Japanese unsupported-zone wording from オカルド・クレセント to クレセントアイル.

## Testing
- `dotnet build BOCCHI.sln -c Release -p:Platform=x64`
- Runtime verified before maintenance: enabling the setting opened the main BOCCHI window when entering the zone.