### PR TITLE
Stop mutating pot FATE allowlist

### DIFF
--- a/BOCCHI.Automator/Services/Automator.cs
+++ b/BOCCHI.Automator/Services/Automator.cs
@@ -43,7 +43,6 @@ public class Automator
     IChatGui chat,
     PotsConfig potsConfig,
     AutomatorConfig automatorConfig,
-    FatesConfig fatesConfig,
     UIConfig uiConfig,
     AutoRotationController autoRotation,
     IAutomationModeGuard modeGuard,
@@ -231,10 +230,6 @@ public class Automator
         }
 
         autoRotation.Tick();
-
-        fatesConfig.EnsurePotFatesAllowedWhenPreferred(
-            automatorConfig.PreferPotFates,
-            automatorConfig.ShouldFarmPotChests);
 
         // Mid-route cancel (vnav stop / emergency) — don't replan until mode is toggled.
         if (memory.TryRemember<NavigationInterruptedMemory>(out NavigationInterruptedMemory _))

--- a/BOCCHI.Common/Config/FatesConfig.cs
+++ b/BOCCHI.Common/Config/FatesConfig.cs
@@ -35,21 +35,6 @@ public class FatesConfig : IAutoConfig
         return isPotFate && (preferPotFates || shouldFarmPotChests);
     }
 
-    /// <summary>Keep Allowed FATEs checkboxes in sync when Prefer / Farm pots is on.</summary>
-    public void EnsurePotFatesAllowedWhenPreferred(bool preferPotFates, bool shouldFarmPotChests)
-    {
-        if (!preferPotFates && !shouldFarmPotChests)
-        {
-            return;
-        }
-
-        DisabledFateIds ??= [];
-        foreach (uint id in PotFateIds)
-        {
-            DisabledFateIds.Remove(id);
-        }
-    }
-
     /// <summary>
     ///     Pot fallback cutoffs only apply when pot farming is on AND the predicted next pot FATE is enabled.
     ///     Disabled pot FATEs must not idle the automator near spawn.

--- a/BOCCHI/Plugin.cs
+++ b/BOCCHI/Plugin.cs
@@ -207,9 +207,6 @@ public sealed class Plugin(IDalamudPluginInterface plugin, IPluginLog logger) : 
         SanitizeTreasureConfig(cfg.TreasureConfig);
         SanitizeBuffConfig(cfg.BuffConfig);
         SanitizeUIConfig(cfg.UIConfig);
-        cfg.FatesConfig.EnsurePotFatesAllowedWhenPreferred(
-            cfg.AutomatorConfig.PreferPotFates,
-            cfg.AutomatorConfig.ShouldFarmPotChests);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Stop mutating the Allowed FATEs config when pot-related Illegal Mode options are enabled.
- Keep user-unchecked Magic Pot FATE checkboxes visually unchecked instead of force-enabling them on config load or while Illegal Mode is running.
- Leave the existing runtime allowance intact: Illegal Mode can still consider Magic Pot FATEs when `Prefer pot FATEs` or `Farm pot chests after pot FATEs` is enabled.

## Bug
There was a config/UI side effect where enabling Illegal Mode with pot options active could remove Magic Pot FATE IDs from `DisabledFateIds`. This made the Allowed FATEs checkboxes turn back on even after the user unchecked them.

## Testing
- `dotnet build BOCCHI.sln -c Release -p:Platform=x64`