### PR TITLE
Respect disabled pot FATEs in Illegal Mode

### DIFF
--- a/BOCCHI.Common/Config/FatesConfig.cs
+++ b/BOCCHI.Common/Config/FatesConfig.cs
@@ -22,18 +22,11 @@ public class FatesConfig : IAutoConfig
     public bool IsFateEnabled(uint fateId) => !DisabledFateIds.Contains(fateId);
 
     /// <summary>
-    ///     Prefer pot FATEs / farm pot chests imply Magic Pot FATEs are allowed for Illegal Mode,
-    ///     even if they were left unchecked under Allowed FATEs.
+    ///     Illegal Mode always respects Allowed FATEs. Pot options only affect priority,
+    ///     prepositioning, and post-FATE chest farming for Magic Pot FATEs that are still enabled.
     /// </summary>
     public bool IsFateEnabledForIllegalMode(uint fateId, bool isPotFate, bool preferPotFates, bool shouldFarmPotChests)
-    {
-        if (IsFateEnabled(fateId))
-        {
-            return true;
-        }
-
-        return isPotFate && (preferPotFates || shouldFarmPotChests);
-    }
+        => IsFateEnabled(fateId);
 
     /// <summary>
     ///     Pot fallback cutoffs only apply when pot farming is on AND the predicted next pot FATE is enabled.

--- a/Translations/en/config.automator.json
+++ b/Translations/en/config.automator.json
@@ -18,11 +18,11 @@
     },
     "prefer_pot_fates": {
       "label": "Prefer pot FATEs",
-      "tooltip": "Pick Magic Pot FATEs when choosing what to do, and allow those FATEs even if they are unchecked under Allowed FATEs. Also turns on pot timing and waiting near pots (see Pot timing)."
+      "tooltip": "Pick enabled Magic Pot FATEs first when choosing what to do. Disabled Magic Pot FATEs under Allowed FATEs are still skipped. Also turns on pot timing and waiting near pots (see Pot timing)."
     },
     "should_farm_pot_chests": {
       "label": "Farm pot chests after pot FATEs",
-      "tooltip": "After a pot FATE ends (not between waves), wait for Cache Me If You Can, drink Magical Elixir, and follow the compass. Keeps going while Cache Me is up; stops when that buff is gone. If you have no buff, elixir, or hints, it visits known chest spots instead. Also allows pot FATEs for Illegal Mode even if they are unchecked under Allowed FATEs. Extra reroll chests are under Pot timing."
+      "tooltip": "After an enabled pot FATE ends (not between waves), wait for Cache Me If You Can, drink Magical Elixir, and follow the compass. Keeps going while Cache Me is up; stops when that buff is gone. If you have no buff, elixir, or hints, it visits known chest spots instead. Extra reroll chests are under Pot timing."
     },
     "should_preposition_to_pots": {
       "label": "Wait near pots before they spawn",

--- a/Translations/en/config.fates.json
+++ b/Translations/en/config.fates.json
@@ -7,7 +7,7 @@
   "fields": {
     "disabled_fate_ids": {
       "label": "Allowed FATEs",
-      "tooltip": "Uncheck a FATE to skip it. Prefer pot FATEs / Farm pot chests still run Magic Pot FATEs even if those are unchecked here.",
+      "tooltip": "Uncheck a FATE to skip it. Illegal Mode will not run unchecked Magic Pot FATEs, even when Prefer pot FATEs or Farm pot chests is enabled.",
       "empty": "No FATEs listed for this zone."
     }
   }


### PR DESCRIPTION
## Summary
- Make Illegal Mode respect the Allowed FATEs list for Magic Pot FATEs.
- `Prefer pot FATEs` / `Farm pot chests after pot FATEs` now only affect enabled Magic Pot FATEs instead of overriding unchecked entries.
- Update English tooltips to describe the new behavior.

## Bug
Magic Pot FATE checkboxes stayed visually unchecked after the previous fix, but Illegal Mode could still run them when pot-related options were enabled. This aligns the runtime behavior with the user's Allowed FATEs selection.

## Testing
- `dotnet build BOCCHI.sln -c Release -p:Platform=x64`